### PR TITLE
Defender audio volume reduction

### DIFF
--- a/Arcade_MiST/Williams 6809 rev.1 Hardware/Defender Hardware/rtl/Defender_MiST.sv
+++ b/Arcade_MiST/Williams 6809 rev.1 Hardware/Defender Hardware/rtl/Defender_MiST.sv
@@ -310,11 +310,11 @@ assign AUDIO_L = dac_o;
 assign AUDIO_R = dac_o;
 
 dac #(
-	.C_bits(8))
+	.C_bits(11))
 dac(
 	.clk_i(clk_0p89),
 	.res_n_i(1),
-	.dac_i(audio),
+	.dac_i({3'd0, audio}),  // silence by 9dB
 	.dac_o(dac_o)
 	);
 


### PR DESCRIPTION
Brings in line with Robotron core to reduce the excessively loud audio.

fixes #71 