### PR TITLE
revert change ");" edited out

### DIFF
--- a/Computer_MiST/Laser310_MiST/rtl/LASER310_TOP.v
+++ b/Computer_MiST/Laser310_MiST/rtl/LASER310_TOP.v
@@ -47,7 +47,7 @@ input		[7:0]	key_code,
 input		[9:0]	SWITCH,
 input				UART_RXD,
 output			UART_TXD
-               
+               );
 
 reg		[3:0]		CLK;
 


### PR DESCRIPTION
I was trying to compile the Laser 310 core, but apparently this little piece of code in `LASER310_TOP.v` has been edited out in the last commit. This PR reverts this change.