### PR TITLE
fixed Jaleco NaughtyBoy/meta/PopF.mra

### DIFF
--- a/Arcade_MiST/Jaleco NaughtyBoy/meta/PopF.mra
+++ b/Arcade_MiST/Jaleco NaughtyBoy/meta/PopF.mra
@@ -8,7 +8,7 @@
 	<rbf>NBoy</rbf>
 
 	<rom index="1"></rom>
-	<rom index='0' md5='fdc3e6937e974389705145449ec71d2c' type='merged|nonmerged|split' zip='popflame.zip | popflamea.zip'>
+	<rom index='0' md5='fdc3e6937e974389705145449ec71d2c' type='merged|nonmerged|split' zip='popflame.zip|popflamea.zip'>
 		<part crc="5e32bbdf" name="ic86.pop"></part>
 		<part crc="b77abf3d" name="ic80.pop"></part>
 		<part crc="945a3c0f" name="ic94.pop"></part>


### PR DESCRIPTION
fixed leading/tailing spaces in zips list.
[mra-tool](https://github.com/mist-devel/mra-tools-c/raw/master/release/linux) complained about zip files not found:
```
warning: zip file not found: popflame.zip 
warning: zip file not found:  popflamea.zip
part not found in zip: ic86.pop (5e32bbdf)
part not found in zip: ic80.pop (b77abf3d)
part not found in zip: ic94.pop (945a3c0f)
part not found in zip: ic100.pop (f9f2343b)
part not found in zip: ic13.pop (2367131e)
part not found in zip: ic3.pop (deed0a8b)
part not found in zip: ic29.pop (7b54f60f)
part not found in zip: ic38.pop (dd2d9601)
```